### PR TITLE
Add bot reply keyboards and BotReply, tracked_link_state entity/migration, and improve scheduler batching

### DIFF
--- a/bot/src/main/java/backend/academy/bot/TelegramPollingService.java
+++ b/bot/src/main/java/backend/academy/bot/TelegramPollingService.java
@@ -1,6 +1,7 @@
 package backend.academy.bot;
 
 import backend.academy.bot.client.ScrapperClient;
+import backend.academy.bot.service.BotReply;
 import backend.academy.bot.service.BotService;
 import com.pengrad.telegrambot.TelegramBot;
 import com.pengrad.telegrambot.model.ChatMember;
@@ -42,13 +43,13 @@ public class TelegramPollingService {
                     System.out.println("Получено сообщение без текста от chatId=" + chatId);
                     continue;
                 }
+                BotReply reply;
                 if (text.startsWith("/")) {
-                    String response = botService.handleCommand(text, chatId);
-                    telegramBot.execute(new SendMessage(chatId, response));
+                    reply = botService.handleCommandWithKeyboard(text, chatId);
                 } else {
-                    String response = botService.handleTextMessage(chatId, text);
-                    telegramBot.execute(new SendMessage(chatId, response));
+                    reply = botService.handleTextMessageWithKeyboard(chatId, text);
                 }
+                telegramBot.execute(new SendMessage(chatId, reply.text()).replyMarkup(reply.keyboard()));
             } else if (update.myChatMember() != null) {
                 // Обработка изменения статуса чата
                 handleMyChatMember(update.myChatMember());

--- a/bot/src/main/java/backend/academy/bot/controller/UpdateController.java
+++ b/bot/src/main/java/backend/academy/bot/controller/UpdateController.java
@@ -35,7 +35,7 @@ public class UpdateController {
             for (Long chatId : linkUpdate.tgChatIds()) {
                 String mode = redisCacheService.getNotificationMode(chatId);
 
-                if ("immediate".equals(mode)) {
+                if (isImmediateMode(mode)) {
                     sendNotification(chatId, linkUpdate);
                 } else {
                     // Сохраняем уведомление в Redis для дайджеста
@@ -50,6 +50,10 @@ public class UpdateController {
         }
 
         return ResponseEntity.ok().build();
+    }
+
+    private boolean isImmediateMode(String mode) {
+        return mode == null || "immediate".equals(mode);
     }
 
     private void sendNotification(Long chatId, LinkUpdate update) {

--- a/bot/src/main/java/backend/academy/bot/kafka/KafkaConsumerService.java
+++ b/bot/src/main/java/backend/academy/bot/kafka/KafkaConsumerService.java
@@ -40,7 +40,7 @@ public class KafkaConsumerService {
                 for (Long chatId : linkUpdate.tgChatIds()) {
                     String mode = redisCacheService.getNotificationMode(chatId);
 
-                    if ("immediate".equals(mode)) {
+                    if (isImmediateMode(mode)) {
                         sendNotification(chatId, linkUpdate);
                     } else {
                         // Сохраняем уведомление в Redis для дайджеста
@@ -57,6 +57,10 @@ public class KafkaConsumerService {
             System.err.println("Ошибка при обработке обновления: " + e.getMessage());
             throw e;
         }
+    }
+
+    private boolean isImmediateMode(String mode) {
+        return mode == null || "immediate".equals(mode);
     }
 
     private void sendNotification(Long chatId, LinkUpdate update) {

--- a/bot/src/main/java/backend/academy/bot/service/BotKeyboards.java
+++ b/bot/src/main/java/backend/academy/bot/service/BotKeyboards.java
@@ -1,0 +1,51 @@
+package backend.academy.bot.service;
+
+import com.pengrad.telegrambot.model.request.ReplyKeyboardMarkup;
+
+public final class BotKeyboards {
+    public static final String TRACK = "➕ Добавить ссылку";
+    public static final String LIST = "📋 Мои ссылки";
+    public static final String UNTRACK = "➖ Удалить ссылку";
+    public static final String TAGS = "🏷 Теги";
+    public static final String SETTINGS = "🔔 Уведомления";
+    public static final String HELP = "❓ Помощь";
+
+    public static final String ADD_TAGS = "➕ Добавить теги";
+    public static final String LIST_TAGS = "📎 Теги ссылки";
+    public static final String FILTER_BY_TAG = "🔎 Найти по тегу";
+    public static final String REMOVE_TAG = "🗑 Удалить тег";
+
+    public static final String IMMEDIATE_MODE = "⚡ Сразу";
+    public static final String DIGEST_MODE = "🗞 Дайджест";
+
+    public static final String SKIP = "⏭ Пропустить";
+    public static final String CANCEL = "❌ Отмена";
+    public static final String BACK = "⬅️ Назад";
+
+    private BotKeyboards() {}
+
+    public static ReplyKeyboardMarkup mainMenu() {
+        return keyboard(new String[] {TRACK, LIST}, new String[] {UNTRACK, TAGS}, new String[] {SETTINGS, HELP});
+    }
+
+    public static ReplyKeyboardMarkup tagsMenu() {
+        return keyboard(
+                new String[] {ADD_TAGS, LIST_TAGS}, new String[] {FILTER_BY_TAG, REMOVE_TAG}, new String[] {BACK});
+    }
+
+    public static ReplyKeyboardMarkup settingsMenu() {
+        return keyboard(new String[] {IMMEDIATE_MODE, DIGEST_MODE}, new String[] {BACK});
+    }
+
+    public static ReplyKeyboardMarkup inputMenu() {
+        return keyboard(new String[] {CANCEL});
+    }
+
+    public static ReplyKeyboardMarkup optionalInputMenu() {
+        return keyboard(new String[] {SKIP, CANCEL});
+    }
+
+    private static ReplyKeyboardMarkup keyboard(String[]... rows) {
+        return new ReplyKeyboardMarkup(rows).resizeKeyboard(true).isPersistent(true);
+    }
+}

--- a/bot/src/main/java/backend/academy/bot/service/BotReply.java
+++ b/bot/src/main/java/backend/academy/bot/service/BotReply.java
@@ -1,0 +1,5 @@
+package backend.academy.bot.service;
+
+import com.pengrad.telegrambot.model.request.Keyboard;
+
+public record BotReply(String text, Keyboard keyboard) {}

--- a/bot/src/main/java/backend/academy/bot/service/BotService.java
+++ b/bot/src/main/java/backend/academy/bot/service/BotService.java
@@ -32,94 +32,120 @@ public class BotService {
     }
     // Обработка команд
     public String handleCommand(String command, long chatId) {
+        return handleCommandWithKeyboard(command, chatId).text();
+    }
+
+    public BotReply handleCommandWithKeyboard(String command, long chatId) {
         if (command == null) {
             System.out.println("Текст сообщения равен null. Пропускаем обработку.");
-            return "Извините, я не могу обработать это сообщение.";
+            return mainReply("Извините, я не могу обработать это сообщение.");
         }
         switch (command) {
             case "/start":
                 communicationService.registerChat(chatId);
                 redisCacheService.setNotificationMode(chatId, "immediate");
-                return "Добро пожаловать! Используйте /help для просмотра доступных команд.";
+                return mainReply(
+                        "Добро пожаловать! Я добавил удобные кнопки ниже — начните с добавления ссылки или посмотрите список отслеживаемого.");
             case "/help":
-                return """
-                    Доступные команды:
-                    /start - регистрация пользователя
-                    /track - добавить ссылку для отслеживания
-                    /untrack - удалить ссылку из отслеживания
-                    /list - показать список отслеживаемых ссылок
-                    /addtags <url> <tag1> <tag2> ... — добавить теги к ссылке.
-                    /removetag <url> <tag> — удалить тег из ссылки.
-                    /listtags <url> — показать все теги для ссылки.
-                    /filterbytag <tag> — показать только ссылки с указанным тегом.
-                    /settings - показать настройки уведомлений
-                    /setmode <immediate|digest> - выбрать режим уведомлений
-                    """;
+                return mainReply(
+                        """
+                    Главное меню вынесено в кнопки:
+                    ➕ Добавить ссылку — основной сценарий отслеживания.
+                    📋 Мои ссылки — быстрый просмотр всех ссылок.
+                    ➖ Удалить ссылку — остановить отслеживание.
+                    🏷 Теги — добавить, удалить, посмотреть теги и фильтровать ссылки.
+                    🔔 Уведомления — выбрать моментальные уведомления или ежедневный дайджест.
+
+                    Команды через / по-прежнему работают, если они вам удобны.
+                    """);
             case "/track":
                 botStateMachine.setState(chatId, "waiting_for_link");
-                return "Введите ссылку для отслеживания.";
+                return inputReply("Отправьте ссылку, которую нужно отслеживать.");
             case "/untrack":
                 botStateMachine.setState(chatId, "waiting_for_untrack_link");
-                return "Введите ссылку для удаления.";
+                return inputReply("Отправьте ссылку, которую нужно удалить из отслеживания.");
             case "/list":
                 ListLinksResponse linksResponse = communicationService.getLinks(chatId);
                 if (linksResponse.links().isEmpty()) {
-                    return "У вас нет отслеживаемых ссылок.";
+                    return mainReply("У вас пока нет отслеживаемых ссылок. Нажмите «➕ Добавить ссылку», чтобы начать.");
                 }
-                return "Ваши отслеживаемые ссылки:\n"
-                        + linksResponse.links().stream().map(LinkResponse::url).collect(Collectors.joining("\n"));
+                return mainReply("Ваши отслеживаемые ссылки:\n"
+                        + linksResponse.links().stream().map(LinkResponse::url).collect(Collectors.joining("\n")));
             case "/addtags":
                 botStateMachine.setState(chatId, "waiting_for_addtags");
-                return "Введите URL и теги через пробел.";
+                return inputReply("Отправьте URL и теги через пробел. Например: https://example.com java backend");
             case "/removetag":
                 botStateMachine.setState(chatId, "waiting_for_removetag");
-                return "Введите URL и имя тега через пробел.";
+                return inputReply("Отправьте URL и имя тега через пробел. Например: https://example.com java");
             case "/listtags":
                 botStateMachine.setState(chatId, "waiting_for_listtags");
-                return "Введите URL для просмотра тегов.";
+                return inputReply("Отправьте URL ссылки, для которой нужно показать теги.");
             case "/filterbytag":
                 botStateMachine.setState(chatId, "waiting_for_filterbytag");
-                return "Введите имя тега для фильтрации ссылок.";
+                return inputReply("Отправьте имя тега, по которому нужно найти ссылки.");
             case "/settings":
                 String mode = redisCacheService.getNotificationMode(chatId);
-                return "Текущий режим уведомлений: " + (mode != null ? mode : "сразу");
+                return settingsReply("Текущий режим уведомлений: " + formatNotificationMode(mode)
+                        + "\nВыберите удобный режим кнопкой ниже.");
 
             case "/setmode immediate":
                 redisCacheService.setNotificationMode(chatId, "immediate");
-                return "Режим уведомлений установлен: сразу.";
+                return mainReply("Режим уведомлений установлен: сразу.");
 
             case "/setmode digest":
                 redisCacheService.setNotificationMode(chatId, "digest");
-                return "Режим уведомлений установлен: дайджест раз в сутки.";
+                return mainReply("Режим уведомлений установлен: дайджест раз в сутки.");
             default:
-                return "Неизвестная команда. Используйте /help для просмотра доступных команд.";
+                return mainReply("Неизвестная команда. Используйте /help для просмотра доступных команд.");
         }
     }
 
     // Обработка текстовых сообщений
     public String handleTextMessage(long chatId, String message) {
+        return handleTextMessageWithKeyboard(chatId, message).text();
+    }
+
+    public BotReply handleTextMessageWithKeyboard(long chatId, String message) {
+        if (message == null) {
+            return mainReply("Извините, я не могу обработать это сообщение.");
+        }
+        if (BotKeyboards.CANCEL.equals(message)) {
+            botStateMachine.clearState(chatId);
+            return mainReply("Действие отменено. Выберите следующий шаг в меню.");
+        }
+
         String currentState = botStateMachine.getState(chatId);
+        if (currentState == null || currentState.isEmpty()) {
+            return handleMenuMessage(message, chatId);
+        }
+
+        if (BotKeyboards.SKIP.equals(message)) {
+            message = "-";
+        }
+
         switch (currentState) {
             case "waiting_for_link":
                 if (!isValidUrl(message)) {
                     botStateMachine.clearState(chatId);
-                    return "Некорректная ссылка. Пожалуйста, введите корректный URL.";
+                    return mainReply(
+                            "Некорректная ссылка. Пожалуйста, нажмите «➕ Добавить ссылку» и отправьте корректный URL.");
                 }
 
                 // Получаем текущие ссылки для чата
+                String trackedLinkCandidate = message;
                 ListLinksResponse linksResponse = communicationService.getLinks(chatId);
                 boolean isLinkAlreadyTracked = linksResponse.links().stream()
-                        .anyMatch(link -> link.url().equals(message));
+                        .anyMatch(link -> link.url().equals(trackedLinkCandidate));
 
                 if (isLinkAlreadyTracked) {
                     botStateMachine.clearState(chatId);
-                    return "Ссылка уже отслеживается.";
+                    return mainReply("Ссылка уже отслеживается.");
                 }
 
                 // Добавляем ссылку
                 botStateMachine.setPendingLink(chatId, message);
                 botStateMachine.setState(chatId, "waiting_for_tags");
-                return "Введите тэги (через пробел). Если тэги не нужны, отправьте -";
+                return optionalInputReply("Введите теги через пробел или нажмите «⏭ Пропустить», если теги не нужны.");
             case "waiting_for_tags":
                 List<String> tags = Arrays.asList(message.trim().split("\\s+"));
                 if (tags.size() == 1 && "-".equals(tags.get(0))) {
@@ -128,7 +154,8 @@ public class BotService {
                     botStateMachine.setPendingTags(chatId, tags);
                 }
                 botStateMachine.setState(chatId, "waiting_for_filters");
-                return "Настройте фильтры (например, user:dummy type:comment). Если фильтры не нужны, отправьте -";
+                return optionalInputReply(
+                        "Настройте фильтры (например, user:dummy type:comment) или нажмите «⏭ Пропустить».");
 
             case "waiting_for_filters":
                 List<String> filters = Arrays.asList(message.trim().split("\\s+"));
@@ -145,42 +172,100 @@ public class BotService {
 
                 communicationService.addLink(chatId, link, pendingTags, pendingFilters);
                 botStateMachine.clearState(chatId);
-                return "Ссылка успешно добавлена с тэгами: " + pendingTags + " и фильтрами: " + pendingFilters;
+                return mainReply(
+                        "Ссылка успешно добавлена с тегами: " + pendingTags + " и фильтрами: " + pendingFilters);
             case "waiting_for_untrack_link":
                 communicationService.removeLink(chatId, message);
                 botStateMachine.clearState(chatId);
-                return "Ссылка удалена из отслеживания.";
+                return mainReply("Ссылка удалена из отслеживания.");
 
             case "waiting_for_addtags":
-                String[] parts = message.split(" ");
+                String[] parts = message.trim().split("\\s+");
+                if (parts.length < 2) {
+                    return inputReply("Нужно отправить URL и хотя бы один тег. Например: https://example.com java");
+                }
                 String url = parts[0];
                 List<String> tagsForUrl = Arrays.asList(Arrays.copyOfRange(parts, 1, parts.length));
                 communicationService.addTags(chatId, url, tagsForUrl);
                 botStateMachine.clearState(chatId);
-                return "Теги успешно добавлены.";
+                return mainReply("Теги успешно добавлены.");
 
             case "waiting_for_removetag":
-                String[] removeParts = message.split(" ");
+                String[] removeParts = message.trim().split("\\s+");
+                if (removeParts.length < 2) {
+                    return inputReply("Нужно отправить URL и имя тега. Например: https://example.com java");
+                }
                 String removeUrl = removeParts[0];
                 String tagName = removeParts[1];
                 communicationService.removeTag(chatId, removeUrl, tagName);
                 botStateMachine.clearState(chatId);
-                return "Тег успешно удален.";
+                return mainReply("Тег успешно удален.");
 
             case "waiting_for_listtags":
                 List<String> tagsList = communicationService.getTagsForLink(chatId, message);
                 botStateMachine.clearState(chatId);
-                return "Теги для ссылки: " + String.join(", ", tagsList);
+                return mainReply("Теги для ссылки: " + String.join(", ", tagsList));
 
             case "waiting_for_filterbytag":
                 List<LinkResponse> filteredLinks = communicationService.getLinksByTag(chatId, message);
                 botStateMachine.clearState(chatId);
-                return "Ссылки с тегом '" + message + "':\n"
-                        + filteredLinks.stream().map(LinkResponse::url).collect(Collectors.joining("\n"));
+                return mainReply("Ссылки с тегом '" + message + "':\n"
+                        + filteredLinks.stream().map(LinkResponse::url).collect(Collectors.joining("\n")));
 
             default:
-                return "Неизвестное сообщение. Используйте /help для просмотра доступных команд.";
+                return mainReply("Неизвестное сообщение. Выберите действие кнопкой ниже или используйте /help.");
         }
+    }
+
+    private BotReply handleMenuMessage(String message, long chatId) {
+        return switch (message) {
+            case BotKeyboards.TRACK -> handleCommandWithKeyboard("/track", chatId);
+            case BotKeyboards.LIST -> handleCommandWithKeyboard("/list", chatId);
+            case BotKeyboards.UNTRACK -> handleCommandWithKeyboard("/untrack", chatId);
+            case BotKeyboards.ADD_TAGS -> handleCommandWithKeyboard("/addtags", chatId);
+            case BotKeyboards.REMOVE_TAG -> handleCommandWithKeyboard("/removetag", chatId);
+            case BotKeyboards.LIST_TAGS -> handleCommandWithKeyboard("/listtags", chatId);
+            case BotKeyboards.FILTER_BY_TAG -> handleCommandWithKeyboard("/filterbytag", chatId);
+            case BotKeyboards.HELP, BotKeyboards.BACK -> handleCommandWithKeyboard("/help", chatId);
+            case BotKeyboards.SETTINGS -> handleCommandWithKeyboard("/settings", chatId);
+            case BotKeyboards.IMMEDIATE_MODE -> handleCommandWithKeyboard("/setmode immediate", chatId);
+            case BotKeyboards.DIGEST_MODE -> handleCommandWithKeyboard("/setmode digest", chatId);
+            case BotKeyboards.TAGS -> tagsReply("Выберите действие с тегами.");
+            default -> {
+                if (message != null && message.startsWith("/")) {
+                    yield handleCommandWithKeyboard(message, chatId);
+                }
+                yield mainReply("Неизвестное сообщение. Выберите действие кнопкой ниже или используйте /help.");
+            }
+        };
+    }
+
+    private BotReply mainReply(String text) {
+        return new BotReply(text, BotKeyboards.mainMenu());
+    }
+
+    private BotReply tagsReply(String text) {
+        return new BotReply(text, BotKeyboards.tagsMenu());
+    }
+
+    private BotReply settingsReply(String text) {
+        return new BotReply(text, BotKeyboards.settingsMenu());
+    }
+
+    private BotReply inputReply(String text) {
+        return new BotReply(text, BotKeyboards.inputMenu());
+    }
+
+    private BotReply optionalInputReply(String text) {
+        return new BotReply(text, BotKeyboards.optionalInputMenu());
+    }
+
+    private String formatNotificationMode(String mode) {
+        return switch (mode == null ? "immediate" : mode) {
+            case "digest" -> "дайджест раз в сутки";
+            case "immediate" -> "сразу";
+            default -> mode;
+        };
     }
 
     @Scheduled(cron = "${app.digest}") // Например, "0 0 10 * * ?" (каждый день в 10:00)

--- a/bot/src/test/java/backend/academy/bot/controller/UpdateControllerTest.java
+++ b/bot/src/test/java/backend/academy/bot/controller/UpdateControllerTest.java
@@ -1,0 +1,32 @@
+package backend.academy.bot.controller;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import backend.academy.bot.client.TelegramClient;
+import backend.academy.bot.service.RedisCacheService;
+import backend.academy.model.LinkUpdate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class UpdateControllerTest {
+    private final TelegramClient telegramClient = Mockito.mock(TelegramClient.class);
+    private final RedisCacheService redisCacheService = Mockito.mock(RedisCacheService.class);
+    private final UpdateController updateController = new UpdateController(telegramClient, redisCacheService);
+
+    @Test
+    void shouldSendImmediateNotificationWhenNotificationModeIsNotConfigured() {
+        long chatId = 1L;
+        LinkUpdate update = new LinkUpdate(chatId, "https://github.com/example/repo", "new issue", List.of(chatId));
+        when(redisCacheService.getNotificationMode(chatId)).thenReturn(null);
+
+        updateController.handleUpdate(update);
+
+        verify(telegramClient).sendMessage(eq(chatId), contains(update.url()));
+        verify(redisCacheService, never()).addNotificationToBatch(eq(chatId), Mockito.anyString());
+    }
+}

--- a/bot/src/test/java/backend/academy/bot/kafka/KafkaConsumerServiceUnitTest.java
+++ b/bot/src/test/java/backend/academy/bot/kafka/KafkaConsumerServiceUnitTest.java
@@ -1,0 +1,34 @@
+package backend.academy.bot.kafka;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import backend.academy.bot.client.TelegramClient;
+import backend.academy.bot.service.RedisCacheService;
+import backend.academy.model.LinkUpdate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class KafkaConsumerServiceUnitTest {
+    private final TelegramClient telegramClient = Mockito.mock(TelegramClient.class);
+    private final KafkaCommunicationService kafkaCommunicationService = Mockito.mock(KafkaCommunicationService.class);
+    private final RedisCacheService redisCacheService = Mockito.mock(RedisCacheService.class);
+    private final KafkaConsumerService kafkaConsumerService =
+            new KafkaConsumerService(telegramClient, kafkaCommunicationService, redisCacheService);
+
+    @Test
+    void shouldSendImmediateNotificationWhenNotificationModeIsNotConfigured() {
+        long chatId = 1L;
+        LinkUpdate update = new LinkUpdate(chatId, "https://github.com/example/repo", "new issue", List.of(chatId));
+        when(redisCacheService.getNotificationMode(chatId)).thenReturn(null);
+
+        kafkaConsumerService.handleLinkUpdate(update);
+
+        verify(telegramClient).sendMessage(eq(chatId), contains(update.url()));
+        verify(redisCacheService, never()).addNotificationToBatch(eq(chatId), Mockito.anyString());
+    }
+}

--- a/migrations/00-initial-schema.sql
+++ b/migrations/00-initial-schema.sql
@@ -27,7 +27,26 @@ CREATE TABLE filter (
     value TEXT NOT NULL
 );
 
+-- Проектная таблица состояния отслеживаемого ресурса
+CREATE TABLE tracked_link_state (
+    tracked_link_state_id BIGSERIAL PRIMARY KEY,
+    tracked_link_id BIGINT NOT NULL,
+    last_event_id TEXT,
+    last_activity_at TIMESTAMP,
+    state_hash TEXT,
+    state_payload JSONB,
+    checked_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT fk_tracked_link_state_link
+        FOREIGN KEY (tracked_link_id)
+        REFERENCES tracked_link(id)
+        ON DELETE CASCADE,
+    CONSTRAINT uq_tracked_link_state_link UNIQUE (tracked_link_id)
+);
+
 -- Индексы
 CREATE INDEX idx_tracked_link_chat_id ON tracked_link(chat_id);
 CREATE INDEX idx_tag_link_id ON tag(link_id);
 CREATE INDEX idx_filter_link_id ON filter(link_id);
+CREATE INDEX idx_tracked_link_state_tracked_link_id ON tracked_link_state(tracked_link_id);

--- a/scrapper/src/main/java/backend/academy/scrapper/repository/DTO/TrackedLinkState.java
+++ b/scrapper/src/main/java/backend/academy/scrapper/repository/DTO/TrackedLinkState.java
@@ -1,0 +1,118 @@
+package backend.academy.scrapper.repository.DTO;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tracked_link_state")
+public class TrackedLinkState {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tracked_link_state_id")
+    private Long trackedLinkStateId;
+
+    @OneToOne
+    @JoinColumn(name = "tracked_link_id", nullable = false)
+    private TrackedLink trackedLink;
+
+    @Column(name = "last_event_id")
+    private String lastEventId;
+
+    @Column(name = "last_activity_at")
+    private LocalDateTime lastActivityAt;
+
+    @Column(name = "state_hash")
+    private String stateHash;
+
+    @Column(name = "state_payload", columnDefinition = "jsonb")
+    private JsonNode statePayload;
+
+    @Column(name = "checked_at")
+    private LocalDateTime checkedAt;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public Long getTrackedLinkStateId() {
+        return trackedLinkStateId;
+    }
+
+    public void setTrackedLinkStateId(Long trackedLinkStateId) {
+        this.trackedLinkStateId = trackedLinkStateId;
+    }
+
+    public TrackedLink getTrackedLink() {
+        return trackedLink;
+    }
+
+    public void setTrackedLink(TrackedLink trackedLink) {
+        this.trackedLink = trackedLink;
+    }
+
+    public String getLastEventId() {
+        return lastEventId;
+    }
+
+    public void setLastEventId(String lastEventId) {
+        this.lastEventId = lastEventId;
+    }
+
+    public LocalDateTime getLastActivityAt() {
+        return lastActivityAt;
+    }
+
+    public void setLastActivityAt(LocalDateTime lastActivityAt) {
+        this.lastActivityAt = lastActivityAt;
+    }
+
+    public String getStateHash() {
+        return stateHash;
+    }
+
+    public void setStateHash(String stateHash) {
+        this.stateHash = stateHash;
+    }
+
+    public JsonNode getStatePayload() {
+        return statePayload;
+    }
+
+    public void setStatePayload(JsonNode statePayload) {
+        this.statePayload = statePayload;
+    }
+
+    public LocalDateTime getCheckedAt() {
+        return checkedAt;
+    }
+
+    public void setCheckedAt(LocalDateTime checkedAt) {
+        this.checkedAt = checkedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/scrapper/src/main/java/backend/academy/scrapper/repository/DTO/TrackedLinkState.java
+++ b/scrapper/src/main/java/backend/academy/scrapper/repository/DTO/TrackedLinkState.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "tracked_link_state")
@@ -32,6 +34,7 @@ public class TrackedLinkState {
     @Column(name = "state_hash")
     private String stateHash;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "state_payload", columnDefinition = "jsonb")
     private JsonNode statePayload;
 

--- a/scrapper/src/main/java/backend/academy/scrapper/repository/repos/TrackedLinkStateRepository.java
+++ b/scrapper/src/main/java/backend/academy/scrapper/repository/repos/TrackedLinkStateRepository.java
@@ -1,0 +1,9 @@
+package backend.academy.scrapper.repository.repos;
+
+import backend.academy.scrapper.repository.DTO.TrackedLinkState;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrackedLinkStateRepository extends JpaRepository<TrackedLinkState, Long> {
+    Optional<TrackedLinkState> findByTrackedLinkId(Long trackedLinkId);
+}

--- a/scrapper/src/main/java/backend/academy/scrapper/service/LinkCheckerScheduler.java
+++ b/scrapper/src/main/java/backend/academy/scrapper/service/LinkCheckerScheduler.java
@@ -93,24 +93,17 @@ public class LinkCheckerScheduler {
         executor.shutdown(); // Останавливаем пул потоков после завершения
     }
 
-    private List<List<LinkResponse>> splitIntoSubBatches(List<LinkResponse> links, int numThreads) {
+    List<List<LinkResponse>> splitIntoSubBatches(List<LinkResponse> links, int numThreads) {
         // Если список ссылок пустой, возвращаем пустой список
         if (links.isEmpty()) {
             return Collections.emptyList();
         }
 
-        // Если размер списка меньше или равен числу потоков, каждый поток обрабатывает одну ссылку
-        if (links.size() <= numThreads) {
-            return links.stream()
-                    .map(Collections::singletonList) // Каждая ссылка в отдельном списке
-                    .toList();
-        }
+        int effectiveNumThreads = Math.max(1, numThreads);
+        int subBatchSize = Math.max(1, (int) Math.ceil((double) links.size() / effectiveNumThreads));
 
-        // Иначе делим список на подбатчи
-        int subBatchSize = (int) Math.ceil((double) links.size() / numThreads);
-        return IntStream.range(0, numThreads)
-                .mapToObj(i -> links.subList(i * subBatchSize, Math.min((i + 1) * subBatchSize, links.size())))
-                .filter(subList -> !subList.isEmpty()) // Исключаем пустые подсписки
+        return IntStream.iterate(0, startIndex -> startIndex < links.size(), startIndex -> startIndex + subBatchSize)
+                .mapToObj(startIndex -> links.subList(startIndex, Math.min(startIndex + subBatchSize, links.size())))
                 .toList();
     }
 

--- a/scrapper/src/test/java/backend/academy/scrapper/repository/AbstractIntegrationTest.java
+++ b/scrapper/src/test/java/backend/academy/scrapper/repository/AbstractIntegrationTest.java
@@ -1,13 +1,11 @@
 package backend.academy.scrapper.repository;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 @Testcontainers(disabledWithoutDocker = true)
 public abstract class AbstractIntegrationTest {

--- a/scrapper/src/test/java/backend/academy/scrapper/service/LinkCheckerSchedulerTest.java
+++ b/scrapper/src/test/java/backend/academy/scrapper/service/LinkCheckerSchedulerTest.java
@@ -1,0 +1,45 @@
+package backend.academy.scrapper.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import backend.academy.model.LinkResponse;
+import backend.academy.scrapper.repository.LinkRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LinkCheckerSchedulerTest {
+    private final LinkCheckerScheduler scheduler =
+            new LinkCheckerScheduler(mock(LinkRepository.class), mock(CommunicationService.class), List.of());
+
+    @Test
+    void shouldSplitRemainderBatchWithoutInvalidSubListRange() {
+        List<List<LinkResponse>> batches = scheduler.splitIntoSubBatches(links(5), 4);
+
+        assertThat(batches).hasSize(3);
+        assertThat(batches).extracting(List::size).containsExactly(2, 2, 1);
+    }
+
+    @Test
+    void shouldNotCreateMoreBatchesThanLinksWhenThreadCountIsGreaterThanLinkCount() {
+        List<List<LinkResponse>> batches = scheduler.splitIntoSubBatches(links(3), 10);
+
+        assertThat(batches).hasSize(3);
+        assertThat(batches).extracting(List::size).containsExactly(1, 1, 1);
+    }
+
+    @Test
+    void shouldFallbackToSingleThreadWhenConfiguredThreadCountIsInvalid() {
+        List<List<LinkResponse>> batches = scheduler.splitIntoSubBatches(links(3), 0);
+
+        assertThat(batches).hasSize(1);
+        assertThat(batches.getFirst()).hasSize(3);
+    }
+
+    private List<LinkResponse> links(int count) {
+        return java.util.stream.IntStream.range(0, count)
+                .mapToObj(index ->
+                        new LinkResponse(index, "https://github.com/example/repo/" + index, List.of(), List.of()))
+                .toList();
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a richer Telegram UX by returning message text together with keyboard markup from bot handlers instead of plain text responses. 
- Improve robustness of link checking by persisting per-link state and adding a dedicated `tracked_link_state` table. 
- Make sub-batch splitting deterministic and safe when thread counts or list sizes are edge cases.

### Description

- Introduced a `BotReply` record and `BotKeyboards` helper with predefined keyboard layouts and labels, and refactored `BotService` to return `BotReply` variants (`mainReply`, `inputReply`, `optionalInputReply`, `settingsReply`, `tagsReply`).
- Updated `TelegramPollingService` to use `BotReply` and send keyboard markup with `SendMessage(...).replyMarkup(...)` for both commands and text handling.
- Enhanced `BotService` behavior to handle menu buttons, `CANCEL`/`SKIP` actions, improved command and text flow, input validation, and readable user-facing texts; added `handleCommandWithKeyboard` and `handleTextMessageWithKeyboard` while keeping legacy text-returning wrappers.
- Added `tracked_link_state` DB migration and created `TrackedLinkState` JPA entity plus `TrackedLinkStateRepository` to store per-link state, payload, and timestamps.
- Reworked `LinkCheckerScheduler.splitIntoSubBatches` to avoid invalid sublist ranges, handle zero/invalid thread counts, and compute sub-batch sizes more robustly, and reduced method visibility for testing where applicable.
- Added small helper `isImmediateMode` in `UpdateController` and `KafkaConsumerService` to treat `null` as `immediate` mode.
- Added unit tests: `UpdateControllerTest`, `KafkaConsumerServiceUnitTest`, and `LinkCheckerSchedulerTest` that cover immediate-mode behavior and batch splitting logic.

### Testing

- Ran `UpdateControllerTest` which verifies immediate-mode notifications when mode is not configured, and it passed.
- Ran `KafkaConsumerServiceUnitTest` which verifies immediate-mode notifications for Kafka-driven updates, and it passed.
- Ran `LinkCheckerSchedulerTest` which asserts correct sub-batch splitting for several edge cases, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0639e7298c8323aa39c4e98bef4321)